### PR TITLE
Markdown syntax highlighting

### DIFF
--- a/Nexus.tmTheme
+++ b/Nexus.tmTheme
@@ -271,6 +271,132 @@
         <string>#2F33AB</string>
       </dict>
     </dict>
+    <dict>
+      <key>name</key>
+      <string>Markdown: Linebreak</string>
+      <key>scope</key>
+      <string>text.html.markdown meta.dummy.line-break</string>
+      <key>settings</key>
+      <dict>
+        <key>background</key>
+        <string>#A57706</string>
+        <key>foreground</key>
+        <string>#E0EDDD</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markdown: Raw</string>
+      <key>scope</key>
+      <string>text.html.markdown markup.raw.inline</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#269186</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markdown: Punctuation for Inline Block</string>
+      <key>scope</key>
+      <string>punctuation.definition.raw.markdown</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#269186</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markup: Heading</string>
+      <key>scope</key>
+      <string>markup.heading</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string>bold</string>
+        <key>foreground</key>
+        <string>#cb4b16</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markup: Italic</string>
+      <key>scope</key>
+      <string>markup.italic</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string>italic</string>
+        <key>foreground</key>
+        <string>#839496</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markup: Bold</string>
+      <key>scope</key>
+      <string>markup.bold</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string>bold</string>
+        <key>foreground</key>
+        <string>#586e75</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markdown: Punctuation for Bold, Italic</string>
+      <key>scope</key>
+      <string>punctuation.definition.bold.markdown, punctuation.definition.italic.markdown</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#586e75</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markup: Underline</string>
+      <key>scope</key>
+      <string>markup.underline</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string>underline</string>
+        <key>foreground</key>
+        <string>#839496</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markup: Quote</string>
+      <key>scope</key>
+      <string>markup.quote</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string>italic</string>
+        <key>foreground</key>
+        <string>#268bd2</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markup: Separator</string>
+      <key>scope</key>
+      <string>meta.separator</string>
+      <key>settings</key>
+      <dict>
+        <key>background</key>
+        <string>#eee8d5</string>
+        <key>fontStyle</key>
+        <string>bold</string>
+        <key>foreground</key>
+        <string>#268bd2</string>
+      </dict>
+    </dict>
   </array>
   <key>uuid</key>
   <string>B80CD0D8-613C-46FD-9C06-A1201108BC2A</string>


### PR DESCRIPTION
This commit adds pretty markdown syntax highlighting to the Nexus theme.
Highlighting code is taken from this blog post:
http://www.bram.us/2013/02/08/sublime-text-markdown-syntax-highlighting/
