### PR TITLE
Hide original folders

### DIFF
--- a/Nexus.sublime-theme
+++ b/Nexus.sublime-theme
@@ -576,6 +576,7 @@
 		"parents": [{"class": "tree_row", "attributes": ["selected"]}],
 		"layer0.texture": "Theme - Nexus/assets/folder/group-open-selected.png"
 	},
+	//	- Hide original folders
 	{
 		"class": "icon_folder",
 		"content_margin": [0,0]

--- a/Nexus.sublime-theme
+++ b/Nexus.sublime-theme
@@ -576,6 +576,10 @@
 		"parents": [{"class": "tree_row", "attributes": ["selected"]}],
 		"layer0.texture": "Theme - Nexus/assets/folder/group-open-selected.png"
 	},
+	{
+		"class": "icon_folder",
+		"content_margin": [0,0]
+	},
 
 //	STANDARD TEXT BUTTONS
 //	=========================================================


### PR DESCRIPTION
When trying the theme, original folders were shown, with this the theme icons are the only visible ones
Closes #15
